### PR TITLE
add DENO_CERT with value set to the CA PEM file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,11 @@ test-with-java: clean
 test-with-doh: clean
 	go run . -- curl --doh-url https://cloudflare-dns.com/dns-query https://www.example.com
 
-test-with-js: clean
+test-with-node: clean
 	go run . node experiments/js/get.js
+
+test-with-deno: clean
+	go run . -- deno --allow-net experiments/deno/get.ts
 
 test-with-self: clean
 	go run . go run . curl https://www.example.com

--- a/experiments/deno/get.ts
+++ b/experiments/deno/get.ts
@@ -1,0 +1,1 @@
+await fetch("https://monasticacademy.org");

--- a/httptap.go
+++ b/httptap.go
@@ -544,6 +544,7 @@ func Main() error {
 		"CURL_CA_BUNDLE="+caPath,
 		"REQUESTS_CA_BUNDLE="+caPath,
 		"SSL_CERT_FILE="+caPath,
+		"DENO_CERT="+caPath,
 		"_JAVA_OPTIONS=-Djavax.net.ssl.trustStore="+caPathPKCS12,
 		"JDK_JAVA_OPTIONS=-Djavax.net.ssl.trustStore="+caPathPKCS12,
 		"NODE_EXTRA_CA_CERTS="+caPath,


### PR DESCRIPTION
Looks like deno has its own environment variable for adding CA certs: DENO_CERT. This PR adds this to the list so deno programs can now be run with:

```
httptap -- deno --allow-net src.ts
```