### PR TITLE
Always link to the latest binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Httptap only runs on linux at present. It makes use of linux-specific system cal
 # Install pre-built binary
 
 ```shell
-curl -L https://github.com/monasticacademy/httptap/releases/download/v0.0.7/httptap_linux_x86_64.tar.gz | tar xzf -
+curl -L https://github.com/monasticacademy/httptap/releases/latest/download/httptap_linux_x86_64.tar.gz | tar xzf -
 ```
 
-For all versions and CPU architectures see the [releases page](https://github.com/monasticacademy/httptap/releases/).
+For all versions and CPU architectures see the [latest releases page](https://github.com/monasticacademy/httptap/releases/latest).
 
 # Install with Go
 


### PR DESCRIPTION
A quick README change so the version number doesn't need to be updated every time.