### PR TITLE
Tap connections to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ There are many HAR viewers out there that can visualize this dump file. For exam
 
 Again, what you're looking at here is one HTTP request to https://monasticacademy.org that returns a 308 Redirect, followed by a second HTTP request to https://www.monasticacademy.org that return a 200 OK.
 
+# Reaching localhost
+
+To reach a localhost port, replace "localhost" with "host.httptap.local" or the special IP address 169.254.77.65. Traffic to these destinations will routed to localhost on your machine.
+
+The situation here is that in linux every network namespace automatically gets its own loopback device (127.0.0.1), and these can't be shared. This means that if a process running within httptap tries to connect to 127.0.0.1:1234, it'll actually be connecting to a "different" 127.0.0.1 from another process on your machine listening on this same address and port, and you won't be able to connect.
+
+As a workaround, the address 169.254.77.65 is hardcoded within httptap to route to 127.0.0.1.
+
 # How it works
 
 When you run `httptap -- <command>`, httptap runs `<command>` in an isolated network namespace, injecting a certificate authority created on-the-fly in order to decrypt HTTPS traffic. Here is the process in detail:

--- a/dns.go
+++ b/dns.go
@@ -234,8 +234,15 @@ func dnsTypeCode(t uint16) string {
 	}
 }
 
+// TCP connections to this hostname will be routed to localhost on the host network
+const specialHostName = "host.httptap.local"
+
+// TCP connections to this IP address will be routed to localhost on the host network
+const specialHostIP = "169.254.77.65"
+
+// this map contains hardcoded DNS names
 var specialAddresses = map[string]net.IP{
-	"host.httptap.local.": net.IP{169, 254, 77, 65},
+	specialHostName + ".": net.IP{169, 254, 77, 65},
 }
 
 // handleDNSQuery answers DNS queries according to:

--- a/proxy.go
+++ b/proxy.go
@@ -6,10 +6,10 @@ import (
 )
 
 // proxyTCP proxies data received on one TCP connection to the world, and back the other way.
-func proxyTCP(subprocess net.Conn) {
-	// the connections's "LocalAddr" is actually the place the other side (the subprocess) was trying
+func proxyTCP(dst string, subprocess net.Conn) {
+	// the connections's "LocalAddr" is actually the address that the other side (the subprocess) was trying
 	// to reach, so that's the address we dial in order to proxy
-	world, err := net.Dial("tcp", subprocess.LocalAddr().String())
+	world, err := net.Dial("tcp", dst)
 	if err != nil {
 		// TODO: report errors not related to destination being unreachable
 		subprocess.Close()


### PR DESCRIPTION
This PR makes it possible to tap connections to localhost.

To reach a localhost port, replace "localhost" with "host.httptap.local" or the special IP address 169.254.77.65. Traffic to these destinations will routed to localhost on your machine.

The situation here is that in linux every network namespace automatically gets its own loopback device (127.0.0.1), and these can't be shared. This means that if a process running within httptap tries to connect to 127.0.0.1:1234, it'll actually be connecting to a "different" 127.0.0.1 from another process on your machine listening on this same address and port, and you won't be able to connect. This is quite annoying!

As a workaround, the address 169.254.77.65 is hardcoded within httptap to route to 127.0.0.1. Please let me know if you have any other suggestion.


Fixes #19 