### PR TITLE
fix: catch error on closing writeable files

### DIFF
--- a/experiments/tls/tls-experiment.go
+++ b/experiments/tls/tls-experiment.go
@@ -16,12 +16,18 @@ import (
 	"github.com/joemiller/certin"
 )
 
-func writeCertFile(cert []byte, path string) error {
-	f, err := os.Create(path)
+func writeCertFile(cert []byte, path string) (err error) {
+	var f *os.File
+	f, err = os.Create(path)
 	if err != nil {
 		return fmt.Errorf("error opening pem file for writing: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		closeErr := f.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 
 	err = pem.Encode(f, &pem.Block{
 		Type:  "CERTIFICATE",

--- a/pkg/certfile/certfile.go
+++ b/pkg/certfile/certfile.go
@@ -10,12 +10,19 @@ import (
 )
 
 // WritePEM writes an x509 certificate to a PEM file
-func WritePEM(path string, certificate *x509.Certificate) error {
-	f, err := os.Create(path)
+func WritePEM(path string, certificate *x509.Certificate) (err error) {
+	var f *os.File
+	f, err = os.Create(path)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+
+	defer func() {
+		closeErr := f.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 
 	return pem.Encode(f, &pem.Block{
 		Type:  "CERTIFICATE",


### PR DESCRIPTION
Using `defer f.Close()` on a file that we're writing to can mask errors when closing this file. See a longer discussion at: https://www.joeshaw.org/dont-defer-close-on-writable-files/

This tweaks so that if there were no error already set, then the error returned from `f.Close()` is properly returned to the caller.