### PR TITLE
Do not print ordinary DNS failures as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ test-with-dig-1111: clean
 test-with-nslookup: clean
 	go run . -- nslookup google.com
 
+# should not generate extraneous error messages
+test-nonexistent-domain: clean:
+	go run . -- curl https://notarealdomain.monasticacademy.org
+
 test-with-netcat-11223: clean
 	go run . -- bash -c "netcat example.com 11223 < /dev/null"
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ test-with-curl-pre-resolved-non-tls: clean
 test-with-curl-ipv6:
 	go run . -- bash -c "curl -sL https://ipv6.google.com > out"
 
+test-with-http3:
+	cd experiments/http3get; go build -o /tmp/http3get; cd -
+	go run . -- /tmp/http3get
+
 # works with gvisor stack but not homegrown stack
 test-with-wget: clean
 	go run . -- wget https://example.com -O out

--- a/dns.go
+++ b/dns.go
@@ -26,7 +26,7 @@ func handleDNS(ctx context.Context, w io.Writer, payload []byte) {
 	// resolve the query
 	rrs, err := handleDNSQuery(ctx, &req)
 	if err != nil {
-		errorf("error performing DNS query: %v, sending a response with empty answer", err)
+		verbosef("DNS query returned: %v, sending a response with empty answer", err)
 		// do not abort here, continue on and send a reply with no answer
 	}
 
@@ -272,7 +272,7 @@ func handleDNSQuery(ctx context.Context, req *dns.Msg) ([]dns.RR, error) {
 			var err error
 			ips, err = net.DefaultResolver.LookupIP(ctx, "ip4", question.Name)
 			if err != nil {
-				return nil, fmt.Errorf("the default resolver said: %w", err)
+				return nil, fmt.Errorf("for an A record the default resolver said: %w", err)
 			}
 		}
 
@@ -291,7 +291,7 @@ func handleDNSQuery(ctx context.Context, req *dns.Msg) ([]dns.RR, error) {
 	case dns.TypeAAAA:
 		ips, err := net.DefaultResolver.LookupIP(ctx, "ip6", question.Name)
 		if err != nil {
-			return nil, fmt.Errorf("the default resolver said: %w", err)
+			return nil, fmt.Errorf("for an AAAA record the default resolver said (AAAA record): %w", err)
 		}
 
 		verbosef("resolved %v to %v with default resolver", question.Name, ips)


### PR DESCRIPTION
Previously if the subprocess tried to resolve a domain that didn't exist or didn't have a requested record type (e.g. AAAA) then httptap would print an error in red on standard output. This is now downgraded to a verbose-only output.