### PR TITLE
Do not abort if ipv6 route cannot be created

### DIFF
--- a/httptap.go
+++ b/httptap.go
@@ -429,7 +429,7 @@ func Main() error {
 		LinkIndex: link.Attrs().Index,
 	})
 	if err != nil {
-		return fmt.Errorf("error creating default route: %w", err)
+		verbosef("error creating default ipv6 route: %w, ignoring", err)
 	}
 
 	// find the loopback device

--- a/httptap.go
+++ b/httptap.go
@@ -429,7 +429,7 @@ func Main() error {
 		LinkIndex: link.Attrs().Index,
 	})
 	if err != nil {
-		verbosef("error creating default ipv6 route: %w, ignoring", err)
+		verbosef("error creating default ipv6 route: %v, ignoring", err)
 	}
 
 	// find the loopback device


### PR DESCRIPTION
It seems that if ipv6 is disabled, the netlink call to create an ipv6 route might fail. This need not cause the whole program to abort. This PR makes this error into a warning and continues on.

Fixes #47 